### PR TITLE
fix: 兼容 dsh-turn-fold 的 chat.node 槽位冲突与 POSIX diff awk 语法错误

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 本文件格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，版本号遵循语义化版本。
 
+## [Unreleased]
+
+### 修复
+
+- **兼容 dsh-turn-fold 的用户消息渲染槽位**：`conversation.chat.node` 的 `user` key 改为在槽位回调实际执行时读取已占用的 priority，并自动选择当前最低 priority 再低一级，避免与 `dsh-turn-fold` 等第三方插件固定占用 `-1` 时发生冲突；其他插件继续占用更低 priority 时也会自动避让。
+
 ## [2.3.0] - 2026-08-31
 
 修复批次：适配 dsh 0.1.2 / 0.1.2-alpha.2（兼容 0.1.1-rc.2）。单测 285 例全绿，`verify:host` 装配门禁、`check:dsh` 巡检、`test:probe` 探针全绿；新旧两版 DSH（0.1.1-rc.2 / 0.1.2-alpha.2，Windows）实弹验证通过——撤回按钮、设置页「撤回插件」卡片、快照删除均正常。

--- a/lib/client.js
+++ b/lib/client.js
@@ -1419,6 +1419,15 @@ function buildSettingsCards(React, util, sessionsSvc) {
 }
 
 // src/client/app.js
+function nextShadowPriority(entries, key) {
+  let priority = -1;
+  for (const entry of Array.isArray(entries) ? entries : []) {
+    if (!entry || !entry.options || entry.options.key !== key) continue;
+    const occupied = Number.isFinite(entry.options.priority) ? entry.options.priority : 0;
+    if (occupied <= priority) priority = occupied - 1;
+  }
+  return priority;
+}
 function createApp(React) {
   return function apply(ctx) {
     const slots = ctx.slots;
@@ -1438,17 +1447,16 @@ function createApp(React) {
     const { UserRecallNode } = buildRecallNode(React, util, ctx, sessionsSvc, workspacesSvc);
     const { RecallSettingsCard } = buildSettingsCards(React, util, sessionsSvc);
     for (const slotKey of ["user", "steering"]) {
-      let mounted = false;
-      for (let priority = -1; priority >= -3 && !mounted; priority--) {
-        try {
-          slots.inject("conversation.chat.node", () => slots.register(
+      try {
+        slots.inject("conversation.chat.node", () => {
+          const priority = nextShadowPriority(slots.entries("conversation.chat.node"), slotKey);
+          return slots.register(
             { name: "conversation.chat.node", key: slotKey, priority },
             UserRecallNode
-          ));
-          mounted = true;
-        } catch (error) {
-          if (priority === -3) console.error("[dsh-recall-plugin] slot register failed (" + slotKey + "):", error);
-        }
+          );
+        });
+      } catch (error) {
+        console.error("[dsh-recall-plugin] slot register failed (" + slotKey + "):", error);
       }
     }
     try {

--- a/lib/scripts.posix.js
+++ b/lib/scripts.posix.js
@@ -328,7 +328,7 @@ export function diffScript(root, store, gitExe, tag, base) {
     'set -e -o pipefail',
     collectListsBlock(store, gitExe, root, tag, base),
     "trap 'rm -f \"$tmpc\" \"$tmpt\"' EXIT",
-    'awk -F\'\\t\' -v OFS=\'\\t\' \'.',
+    'awk -F\'\\t\' -v OFS=\'\\t\' \'',
     '  FNR==1 { fidx++ }',
     '  fidx==1 { split($1, a, " "); cur[$2]=a[2]; next }',
     '  { split($1, a, " "); tgt[$2]=a[3] }',

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -12,6 +12,16 @@ import { buildUtil } from './util.js'
 import { buildRecallNode } from './recall-node.js'
 import { buildSettingsCards } from './settings-cards.js'
 
+export function nextShadowPriority(entries, key) {
+  let priority = -1
+  for (const entry of Array.isArray(entries) ? entries : []) {
+    if (!entry || !entry.options || entry.options.key !== key) continue
+    const occupied = Number.isFinite(entry.options.priority) ? entry.options.priority : 0
+    if (occupied <= priority) priority = occupied - 1
+  }
+  return priority
+}
+
 export function createApp(React) {
   return function apply(ctx) {
     // 0.1.2 起 client runner 用 guard facade 包 ctx：只有插件对象 inject 数组
@@ -42,26 +52,25 @@ export function createApp(React) {
     const { UserRecallNode } = buildRecallNode(React, util, ctx, sessionsSvc, workspacesSvc)
     const { RecallSettingsCard } = buildSettingsCards(React, util, sessionsSvc)
 
-    // keyed slot 显式用低于默认 0 的 priority 注册：默认 0 通常被平台/其他
-    // 插件的渲染器占据，不指定 priority 会因 keyed slot 冲突拒载整个插件；
-    // lowest renders，负值恰好覆盖默认渲染器实现撤回 UI。priority -1 也可能
-    // 被别的机器上的插件占用（同样抛冲突），所以递减重试三次——最坏情况只是
-    // 撤回按钮不渲染，绝不让插件加载失败。chat.node 的 keyed key 与节点 UI
-    // 投影 kind 对齐：'user' 是常规用户消息；'steering' 是 agent 运行中插入
-    // 的转向指令——官方仍按用户气泡回显，但 keyed 'user' 不命中，会落到默认
-    // 渲染、撤回按钮缺失。两个 key 各自独立注册，互不抢占。
+    // conversation.chat.node 是 keyed slot，同一 key 的最低 priority 渲染。
+    // 默认平台渲染器通常为 0，dsh-turn-fold 等插件可能已占 -1；旧实现固定
+    // 尝试 -1..-3，但 slots.inject 的回调可能晚于 inject 返回才执行，冲突异常
+    // 无法被外层 try/catch 可靠捕获，实际不会继续重试。改为在 slot 回调真正
+    // 执行时读取现有 entries，为每个 key 动态选择“当前最低值 - 1”，因此既能
+    // 覆盖默认渲染器，也能避开任意第三方插件已占用的负 priority。
+    // chat.node 的 keyed key 与节点 UI 投影 kind 对齐：'user' 是常规用户消息；
+    // 'steering' 是 agent 运行中插入的转向指令。两个 key 独立计算，互不抢占。
     for (const slotKey of ['user', 'steering']) {
-      let mounted = false
-      for (let priority = -1; priority >= -3 && !mounted; priority--) {
-        try {
-          slots.inject('conversation.chat.node', () => slots.register(
+      try {
+        slots.inject('conversation.chat.node', () => {
+          const priority = nextShadowPriority(slots.entries('conversation.chat.node'), slotKey)
+          return slots.register(
             { name: 'conversation.chat.node', key: slotKey, priority },
             UserRecallNode
-          ))
-          mounted = true
-        } catch (error) {
-          if (priority === -3) console.error('[dsh-recall-plugin] slot register failed (' + slotKey + '):', error)
-        }
+          )
+        })
+      } catch (error) {
+        console.error('[dsh-recall-plugin] slot register failed (' + slotKey + '):', error)
       }
     }
 

--- a/tests/unit/client-pure.test.js
+++ b/tests/unit/client-pure.test.js
@@ -12,8 +12,41 @@ import { describe, it, expect } from 'vitest'
 import { buildTree, clockText, sizeText, bytesToMb } from '../../src/client/util.js'
 import { KIND_INFO, summaryText } from '../../src/client/recall-node.js'
 import { groupByLineage } from '../../src/client/settings-cards.js'
+import { nextShadowPriority } from '../../src/client/app.js'
 
 describe('client 纯逻辑', () => {
+  it('nextShadowPriority：无同 key 时从 -1 开始', () => {
+    expect(nextShadowPriority([], 'user')).toBe(-1)
+  })
+
+  it('nextShadowPriority：避开同 key 已占用的最低优先级', () => {
+    expect(nextShadowPriority([
+      { options: { key: 'user', priority: 0 } },
+      { options: { key: 'user', priority: -1 } },
+      { options: { key: 'steering', priority: -7 } },
+    ], 'user')).toBe(-2)
+  })
+
+  it('nextShadowPriority：连续冲突时继续向更低优先级移动', () => {
+    expect(nextShadowPriority([
+      { options: { key: 'user', priority: -1 } },
+      { options: { key: 'user', priority: -2 } },
+      { options: { key: 'user', priority: -3 } },
+    ], 'user')).toBe(-4)
+  })
+
+  it('nextShadowPriority：缺失或非法 priority 按默认 0 处理', () => {
+    expect(nextShadowPriority([
+      { options: { key: 'user' } },
+      { options: { key: 'user', priority: 'bad' } },
+    ], 'user')).toBe(-1)
+  })
+
+  it('nextShadowPriority：空/非法 entries 不阻断计算', () => {
+    expect(nextShadowPriority(null, 'user')).toBe(-1)
+    expect(nextShadowPriority([null, {}, { options: null }], 'user')).toBe(-1)
+  })
+
   it('buildTree：按工作区/会话分组，未知归属进「未知」节点', () => {
     const tree = buildTree([
       { root: '/ws1', workspace: 'ws1', sessionId: 's1', sessionTitle: 'S1', time: 2, id: 'a' },


### PR DESCRIPTION
## 概述

两个客户端/Host 修复，均已在 macOS 上真机验证。

### 1. 与 dsh-turn-fold 等插件的 `conversation.chat.node` 槽位优先级冲突

`dsh-turn-fold` 也接管 `conversation.chat.node` 的 `user` key 并固定占用 `priority=-1`，导致本插件的撤回按钮注册时抛 `keyed slot "conversation.chat.node" already has an entry for key "user" at priority -1`，撤回按钮完全不渲染。

原实现固定尝试 `-1..-3`，但 `slots.inject` 的回调晚于 `inject` 返回才执行，冲突异常无法被外层 `try/catch` 捕获，实际不会继续重试。

**修复**：新增 `nextShadowPriority(entries, key)`，在槽位回调实际执行时读取同一 key 已占用的 `priority`，自动选择「当前最低值 - 1」，既可覆盖默认渲染器，也能避开任意第三方插件占用的负优先级。

### 2. POSIX diff awk 程序多余点号导致预览/回退失败

`lib/scripts.posix.js` 的 `diffScript` 中，awk 程序起始引号后混入一个多余的 `.`：

```diff
-'awk -F\'\\t\' -v OFS=\'\\t\' \'.',
+'awk -F\'\\t\' -v OFS=\'\\t\' \'',
```

生成的脚本以 `awk ... '.` 开头，awk 把 `.` 当作程序源码首字符，在 macOS/Linux 上均报：

```
awk: syntax error at source line 0 context is >>> . <<<
awk: bailing out at source line 0
```

点「撤回」时先执行预览（diff），因此直接失败，无法回退。

## 验证

- 单测：290 通过（新增 `nextShadowPriority` 5 例）
- API 探针：16 通过
- `verify:host` 装配门禁：通过
- macOS 真实 git 冒烟：diff 输出正确变更清单，rollback `ROLLBACK_OK` 且工作区文件真实还原
- DSH Desktop（0.1.2-alpha.1 SDK）实机：撤回按钮出现、点击撤回成功回退、`dsh-turn-fold` 折叠功能正常共存
